### PR TITLE
Change "graph list" endpoint response format

### DIFF
--- a/server/cohort/cohort.controller.js
+++ b/server/cohort/cohort.controller.js
@@ -13,12 +13,13 @@ const { OK } = HttpStatus;
 async function listGraphs({ cohortId, query, options }, res) {
   const where = { cohortId };
   if (query.userId) where.userId = { [Op.in]: query.userId };
-  const profiles = await LearnerProfile.findAll({ where, ...options });
-  const data = profiles.map(it => ({
+  const opts = { where, ...options };
+  const { rows, count } = await LearnerProfile.findAndCountAll(opts);
+  const data = rows.map(it => ({
     ...pick(it, ['cohortId', 'userId', 'progress']),
     ...it.getProfile()
   }));
-  return res.jsend.success(data);
+  return res.jsend.success({ items: data, total: count });
 }
 
 async function getGraph({ cohortId, learnerId }, res) {

--- a/server/cohort/index.js
+++ b/server/cohort/index.js
@@ -13,7 +13,7 @@ router
   .post('/:cohortId/register', ctrl.registerLearners)
   .use('/:cohortId/learner/:learnerId*', parseLearnerId)
   .get('/:cohortId/learner/:learnerId', ctrl.getGraph)
-  .get('/:cohortId/learner/', ctrl.listGraphs);
+  .get('/:cohortId/learner/', ctrl.listLearners);
 
 module.exports = {
   path: '/cohort',

--- a/server/knowledge-graph/learner-profile.model.js
+++ b/server/knowledge-graph/learner-profile.model.js
@@ -117,6 +117,7 @@ class LearnerProfile extends Model {
 
   getProfile() {
     const graph = graphService.get(this.cohortId);
+    if (!graph) return;
     const nodes = map(graph.nodes, node => ({
       ...pick(node, ['id']),
       ...this.getNodeState(node.id)

--- a/server/knowledge-graph/learner-profile.model.js
+++ b/server/knowledge-graph/learner-profile.model.js
@@ -5,7 +5,7 @@ const filter = require('lodash/filter');
 const get = require('lodash/get');
 const graphService = require('./graph.service');
 const map = require('lodash/map');
-const mean = require('lodash/mean');
+const meanBy = require('lodash/meanBy');
 const { Model } = require('sequelize');
 const pick = require('lodash/pick');
 const toArray = require('lodash/toArray');
@@ -94,10 +94,10 @@ class LearnerProfile extends Model {
     }
     // If root node, aggregate accross all repositories
     const rootNodes = graph.getRootNodes();
-    this.progress = mean(rootNodes.map(({ id }) => this.getProgress(id)));
+    this.progress = meanBy(rootNodes, ({ id }) => this.getProgress(id));
     const { repositoryId } = node;
     const repoRootNodes = filter(rootNodes, { repositoryId });
-    const repoProgress = mean(repoRootNodes.map(({ id }) => this.getProgress(id)));
+    const repoProgress = meanBy(repoRootNodes, ({ id }) => this.getProgress(id));
     if (!this.repoState[repositoryId]) {
       this.repoState[repositoryId] = { id: repositoryId };
     }
@@ -111,8 +111,8 @@ class LearnerProfile extends Model {
   }
 
   aggregateProgress(node, timestamp) {
-    const childrenState = node._c.map(id => this.getProgress(id));
-    return this.updateProgress(node.id, mean(childrenState), timestamp);
+    const progress = meanBy(node._c, id => this.getProgress(id));
+    return this.updateProgress(node.id, progress, timestamp);
   }
 
   getGraph() {

--- a/server/knowledge-graph/learner-profile.model.js
+++ b/server/knowledge-graph/learner-profile.model.js
@@ -115,7 +115,7 @@ class LearnerProfile extends Model {
     return this.updateProgress(node.id, mean(childrenState), timestamp);
   }
 
-  getProfile() {
+  getGraph() {
     const graph = graphService.get(this.cohortId);
     if (!graph) return;
     const nodes = map(graph.nodes, node => ({


### PR DESCRIPTION
This PR changes `listGraphs` response format from learner array to object containing learner array (`items`) and count (`total`).