### PR TITLE
Change filter keywords definition

### DIFF
--- a/server/event/event.controller.js
+++ b/server/event/event.controller.js
@@ -10,7 +10,7 @@ const { Op } = Sequelize;
 const commonAttrs = ['userId', 'activityId', 'interactionStart', 'interactionEnd'];
 const ungradedAttrs = ['progress'].concat(commonAttrs);
 const gradedAttrs = ['questionId', 'isCorrect', 'answer'].concat(commonAttrs);
-const ungradedFilterAttrs = ['interactionStart', 'interactionEnd', 'activityIds'];
+const ungradedFilterAttrs = ['fromDate', 'toDate', 'activityIds'];
 const gradedFilterAttrs = ungradedFilterAttrs.concat('questionIds');
 
 function listUngradedEvents({ cohortId, query, options }, res) {


### PR DESCRIPTION
This PR fixes issue with filtering events by date. `interactionStart` and `interactionEnd` are replaced with `fromDate` and `toDate` keywords so request params can be parsed correctly.